### PR TITLE
implemented consensus/types

### DIFF
--- a/consensus/types/basic.go
+++ b/consensus/types/basic.go
@@ -1,15 +1,8 @@
 package types
 
-
-
-
-type ByteList struct{
-
-}
-
-type Address = [20] byte;
-type Bytes32 =[32] byte;
-type LogsBloom =[256] byte;
-type BLSPubKey =[48] byte;
-type SignatureBytes= [96] byte;
-type Transaction =ByteList;//1073741824
+type Address = [20]byte
+type Bytes32 = [32]byte
+type LogsBloom = [256]byte
+type BLSPubKey = [48]byte
+type SignatureBytes = [96]byte
+type Transaction = [1073741824]byte //1073741824

--- a/consensus/types/beacon.go
+++ b/consensus/types/beacon.go
@@ -43,7 +43,7 @@ func Deserialize(data []byte) (*BeaconBlockBody, error) {
 }
 
 
-func (b *BeaconBlockBody) def() {
+func (b *BeaconBlockBody) Def() {
 	b.RandaoReveal = SignatureBytes{}
 	b.Eth1Data = Eth1Data{}
 	b.Graffiti = Bytes32{}
@@ -89,7 +89,7 @@ type ExecutionPayload struct {
 	ExcessBlobGas   uint64        `json:"excess_blob_gas"` // Deneb variant only
 }   // 1 method
 
-func (exe *ExecutionPayload) def() {
+func (exe *ExecutionPayload) Def() {
 	exe.ParentHash = Bytes32{}
 	exe.FeeRecipient = Address{}
 	exe.StateRoot = Bytes32{}
@@ -130,12 +130,12 @@ type Withdrawal struct{
 	ValidatorIndex uint64
 }
 type ProposalSlashing struct {
-	signed_header_1 SignedBeaconBlockHeader
-	signed_header_2 SignedBeaconBlockHeader
+	SignedHeader1 SignedBeaconBlockHeader
+	SignedHeader2 SignedBeaconBlockHeader
 }
 type SignedBeaconBlockHeader struct {
-	message   BeaconBlockHeader
-	signature SignatureBytes
+	Message   BeaconBlockHeader
+	Signature SignatureBytes
 }
 type AttesterSlashing struct{
 	Attestation1 IndexedAttestation
@@ -248,7 +248,7 @@ type GenericUpdate struct{
 	FinalityBranch []Bytes32
 }
 
-func (g GenericUpdate) from() {
+func (g GenericUpdate) From() {
 	g.AttestedHeader = Header{}
 	g.SyncAggregate = SyncAggregate{}
 	g.SignatureSlot = 0

--- a/consensus/types/beacon.go
+++ b/consensus/types/beacon.go
@@ -5,27 +5,27 @@ import (
 )
 
 type BeaconBlock struct {
-	Slot           uint64
+	Slot          uint64
 	ProposerIndex uint64
 	ParentRoot    [32]byte
 	StateRoot     [32]byte
-	Body           BeaconBlockBody
+	Body          BeaconBlockBody
 }
 
 // just implemented the deneb variant
 type BeaconBlockBody struct {
-	RandaoReveal          SignatureBytes               `json:"randao_reveal"`
-	Eth1Data              Eth1Data                     `json:"eth1_data"`
-	Graffiti              Bytes32                      `json:"graffiti"`
-	ProposerSlashings     [16]ProposerSlashing           `json:"proposer_slashings"`       // max length 16 to be ensured
-	AttesterSlashings     [2]AttesterSlashing           `json:"attester_slashings"`       // max length 2 to be ensured
-	Attestations          [128]Attestation                `json:"attestations"`             // max length 128 to be ensured
-	Deposits              [16]Deposit                    `json:"deposits"`                 // max length 16 to be ensured
-	VoluntaryExits        [16]SignedVoluntaryExit        `json:"voluntary_exits"`          // max length 16 to be ensured
-	SyncAggregate         SyncAggregate                `json:"sync_aggregate"`
-	ExecutionPayload      ExecutionPayload             `json:"execution_payload"`
+	RandaoReveal          SignatureBytes                 `json:"randao_reveal"`
+	Eth1Data              Eth1Data                       `json:"eth1_data"`
+	Graffiti              Bytes32                        `json:"graffiti"`
+	ProposerSlashings     [16]ProposerSlashing           `json:"proposer_slashings"` // max length 16 to be ensured
+	AttesterSlashings     [2]AttesterSlashing            `json:"attester_slashings"` // max length 2 to be ensured
+	Attestations          [128]Attestation               `json:"attestations"`       // max length 128 to be ensured
+	Deposits              [16]Deposit                    `json:"deposits"`           // max length 16 to be ensured
+	VoluntaryExits        [16]SignedVoluntaryExit        `json:"voluntary_exits"`    // max length 16 to be ensured
+	SyncAggregate         SyncAggregate                  `json:"sync_aggregate"`
+	ExecutionPayload      ExecutionPayload               `json:"execution_payload"`
 	BlsToExecutionChanges [16]SignedBlsToExecutionChange `json:"bls_to_execution_changes"` // max length 16 to be ensured
-	BlobKzgCommitments    [4096][48]byte                   `json:"blob_kzg_commitments"`     // max length 4096 to be ensured
+	BlobKzgCommitments    [4096][48]byte                 `json:"blob_kzg_commitments"`     // max length 4096 to be ensured
 } // 1 method
 
 // Serialize the BeaconBlockBody to JSON
@@ -37,11 +37,10 @@ func (body *BeaconBlockBody) Serialize() ([]byte, error) {
 func Deserialize(data []byte) (*BeaconBlockBody, error) {
 	var exe BeaconBlockBody
 	if err := json.Unmarshal(data, &exe); err != nil {
-		return nil,err
+		return nil, err
 	}
-	return &exe,nil
+	return &exe, nil
 }
-
 
 func (b *BeaconBlockBody) Def() {
 	b.RandaoReveal = SignatureBytes{}
@@ -58,36 +57,34 @@ func (b *BeaconBlockBody) Def() {
 	b.BlobKzgCommitments = [4096][48]byte{}
 }
 
-
-
-type SignedBlsToExecutionChange struct{
+type SignedBlsToExecutionChange struct {
 	Message   BlsToExecutionChange
 	Signature SignatureBytes
 }
-type BlsToExecutionChange struct{
+type BlsToExecutionChange struct {
 	ValidatorIndex uint64
-	FromBlsPubkey [48]byte
+	FromBlsPubkey  [48]byte
 }
 
 type ExecutionPayload struct {
-	ParentHash      Bytes32       `json:"parent_hash"`
-	FeeRecipient    Address       `json:"fee_recipient"`
-	StateRoot       Bytes32       `json:"state_root"`
-	ReceiptsRoot    Bytes32       `json:"receipts_root"`
-	LogsBloom       LogsBloom     `json:"logs_bloom"`
-	PrevRandao      Bytes32       `json:"prev_randao"`
-	BlockNumber     uint64        `json:"block_number"`
-	GasLimit        uint64        `json:"gas_limit"`
-	GasUsed         uint64        `json:"gas_used"`
-	Timestamp       uint64        `json:"timestamp"`
-	ExtraData       [32]byte      `json:"extra_data"`
-	BaseFeePerGas   uint64        `json:"base_fee_per_gas"`
-	BlockHash       Bytes32       `json:"block_hash"`
-	Transactions    [1073741824]byte        `json:"transactions"`    // max length 1073741824 to be implemented
-	Withdrawals     [16]Withdrawal  `json:"withdrawals"`     // max length 16 to be implemented
-	BlobGasUsed     uint64        `json:"blob_gas_used"`   // Deneb variant only
-	ExcessBlobGas   uint64        `json:"excess_blob_gas"` // Deneb variant only
-}   // 1 method
+	ParentHash    Bytes32          `json:"parent_hash"`
+	FeeRecipient  Address          `json:"fee_recipient"`
+	StateRoot     Bytes32          `json:"state_root"`
+	ReceiptsRoot  Bytes32          `json:"receipts_root"`
+	LogsBloom     LogsBloom        `json:"logs_bloom"`
+	PrevRandao    Bytes32          `json:"prev_randao"`
+	BlockNumber   uint64           `json:"block_number"`
+	GasLimit      uint64           `json:"gas_limit"`
+	GasUsed       uint64           `json:"gas_used"`
+	Timestamp     uint64           `json:"timestamp"`
+	ExtraData     [32]byte         `json:"extra_data"`
+	BaseFeePerGas uint64           `json:"base_fee_per_gas"`
+	BlockHash     Bytes32          `json:"block_hash"`
+	Transactions  [1073741824]byte `json:"transactions"`    // max length 1073741824 to be implemented
+	Withdrawals   [16]Withdrawal   `json:"withdrawals"`     // max length 16 to be implemented
+	BlobGasUsed   uint64           `json:"blob_gas_used"`   // Deneb variant only
+	ExcessBlobGas uint64           `json:"excess_blob_gas"` // Deneb variant only
+} // 1 method
 
 func (exe *ExecutionPayload) Def() {
 	exe.ParentHash = Bytes32{}
@@ -103,10 +100,10 @@ func (exe *ExecutionPayload) Def() {
 	exe.ExtraData = [32]byte{}
 	exe.BaseFeePerGas = 0
 	exe.BlockHash = Bytes32{}
-	exe.Transactions =  [1073741824]byte{}       // max length 1073741824 to be implemented
-	exe.Withdrawals = [16]Withdrawal{}          // max length 16 to be implemented
-	exe.BlobGasUsed = 0           // Only for Deneb
-	exe.ExcessBlobGas = 0         // Only for Deneb
+	exe.Transactions = [1073741824]byte{} // max length 1073741824 to be implemented
+	exe.Withdrawals = [16]Withdrawal{}    // max length 16 to be implemented
+	exe.BlobGasUsed = 0                   // Only for Deneb
+	exe.ExcessBlobGas = 0                 // Only for Deneb
 } // default
 
 // Serialize the Deneb variant to JSON
@@ -123,10 +120,10 @@ func DeserializeExecutionPayload(data []byte) (*ExecutionPayload, error) {
 	return &exe, nil
 }
 
-type Withdrawal struct{
-	Index  uint64
-	Amount uint64
-	Address Address
+type Withdrawal struct {
+	Index          uint64
+	Amount         uint64
+	Address        Address
 	ValidatorIndex uint64
 }
 type ProposalSlashing struct {
@@ -137,48 +134,48 @@ type SignedBeaconBlockHeader struct {
 	Message   BeaconBlockHeader
 	Signature SignatureBytes
 }
-type AttesterSlashing struct{
+type AttesterSlashing struct {
 	Attestation1 IndexedAttestation
 	Attestation2 IndexedAttestation
 }
-type IndexedAttestation struct{
+type IndexedAttestation struct {
 	AttestingIndices [2048]uint64
-	Data AttestationData
-	Signature SignatureBytes
+	Data             AttestationData
+	Signature        SignatureBytes
 }
 type Attestation struct {
-	AggregateBits [2048] bool
+	AggregateBits [2048]bool
 	Data          AttestationData
 	Signature     SignatureBytes
 }
-type AttestationData struct{
-	Slot uint64
-	Index uint64
+type AttestationData struct {
+	Slot            uint64
+	Index           uint64
 	BeaconBlockRoot Bytes32
-	Source Checkpoint
-	Target Checkpoint
+	Source          Checkpoint
+	Target          Checkpoint
 }
-type Checkpoint struct{
+type Checkpoint struct {
 	Epoch uint64
-	Root Bytes32
+	Root  Bytes32
 }
-type SignedVoluntaryExit struct{
-	Message VoluntaryExit
+type SignedVoluntaryExit struct {
+	Message   VoluntaryExit
 	Signature SignatureBytes
 }
-type VoluntaryExit struct{
-	Epoch uint64
+type VoluntaryExit struct {
+	Epoch          uint64
 	ValidatorIndex uint64
 }
-type Deposit struct{
+type Deposit struct {
 	Proof [33]byte
-	Data DepositData
+	Data  DepositData
 }
-type DepositData struct{
-	Pubkey [48]byte
+type DepositData struct {
+	Pubkey               [48]byte
 	WitdrawalCredentials [32]byte
-	Amount uint64
-	Signature SignatureBytes
+	Amount               uint64
+	Signature            SignatureBytes
 }
 type Eth1Data struct {
 	DepositRoot  Bytes32
@@ -186,66 +183,66 @@ type Eth1Data struct {
 	BlockHash    Bytes32
 }
 type BeaconBlockHeader struct {
-	Slot           uint64
+	Slot         uint64
 	ProposeIndex uint64
+	ParentRoot   Bytes32
+	StateRoot    Bytes32
+	BodyRoot     Bytes32
+}
+type Update struct {
+	AttestedHeader         Header
+	NextSyncCommittee      SyncCommittee
+	NextSyncCommitteBranch []Bytes32
+	FinalizedHeader        Header
+	FinalizedBranch        []Bytes32
+	SyncAggregate          SyncAggregate
+	SignatureSlot          uint64
+}
+type FinalityUpdate struct {
+	AttestedHeader  Header
+	FinalizedHeader Header
+	FinalizedBranch []Bytes32
+	SyncAggregate   SyncAggregate
+	SignatureSlot   uint64
+}
+type OptimisticUpdate struct {
+	AttestedHeader Header
+	SyncAggregate  SyncAggregate
+	SignatureSlot  uint64
+}
+type Bootstrap struct {
+	Header                     Header
+	CurrentSyncCommittee       SyncCommittee
+	CurrentSyncCommitteeBranch []Bytes32
+}
+
+type Header struct {
+	Slot          uint64
+	ProposerIndex uint64
 	ParentRoot    Bytes32
 	StateRoot     Bytes32
 	BodyRoot      Bytes32
 }
-type Update struct{
-	AttestedHeader Header
-	NextSyncCommittee SyncCommittee
-	NextSyncCommitteBranch []Bytes32
-	FinalizedHeader Header
-	FinalizedBranch []Bytes32
-	SyncAggregate SyncAggregate
-	SignatureSlot uint64
-}
-type FinalityUpdate struct{
-	AttestedHeader Header
-	FinalizedHeader Header
-	FinalizedBranch []Bytes32
-	SyncAggregate SyncAggregate
-	SignatureSlot uint64
-}
-type OptimisticUpdate struct{
-	AttestedHeader Header
-	SyncAggregate SyncAggregate
-	SignatureSlot uint64
-}
-type Bootstrap struct{
-	Header Header
-	CurrentSyncCommittee SyncCommittee
-	CurrentSyncCommitteeBranch []Bytes32
-}
-
-type Header struct{
-	Slot uint64
-	ProposerIndex uint64
-	ParentRoot Bytes32
-	StateRoot Bytes32
-	BodyRoot Bytes32
-}
-type SyncCommittee struct{
-	Pubkeys [512]BLSPubKey
+type SyncCommittee struct {
+	Pubkeys         [512]BLSPubKey
 	AggregatePubkey BLSPubKey
 }
-type SyncAggregate struct{
-	SyncCommitteeBits [512] bool
+type SyncAggregate struct {
+	SyncCommitteeBits      [512]bool
 	SyncCommitteeSignature SignatureBytes
 }
 type ProposerSlashing struct {
 	SignedHeader1 SignedBeaconBlockHeader
 	SignedHeader2 SignedBeaconBlockHeader
 }
-type GenericUpdate struct{
-	AttestedHeader Header
-	SyncAggregate SyncAggregate
-	SignatureSlot uint64
-	NextSyncCommittee SyncCommittee
+type GenericUpdate struct {
+	AttestedHeader          Header
+	SyncAggregate           SyncAggregate
+	SignatureSlot           uint64
+	NextSyncCommittee       SyncCommittee
 	NextSyncCommitteeBranch []Bytes32
-	FinalizedHeader Header
-	FinalityBranch []Bytes32
+	FinalizedHeader         Header
+	FinalityBranch          []Bytes32
 }
 
 func (g GenericUpdate) From() {

--- a/consensus/types/beacon.go
+++ b/consensus/types/beacon.go
@@ -1,39 +1,259 @@
 package types
 
+import (
+	"encoding/json"
+)
 
-type BeaconBlock struct{}
-type BeaconBlockBody struct{}// 1 method
-func (b BeaconBlockBody) def(){}//default
+type BeaconBlock struct {
+	Slot           uint64
+	ProposerIndex uint64
+	ParentRoot    [32]byte
+	StateRoot     [32]byte
+	Body           BeaconBlockBody
+}
 
-type SignedBlsToExecutionChange struct{}
-type BlsToExecutionChange struct{}
+// just implemented the deneb variant
+type BeaconBlockBody struct {
+	RandaoReveal          SignatureBytes               `json:"randao_reveal"`
+	Eth1Data              Eth1Data                     `json:"eth1_data"`
+	Graffiti              Bytes32                      `json:"graffiti"`
+	ProposerSlashings     [16]ProposerSlashing           `json:"proposer_slashings"`       // max length 16 to be ensured
+	AttesterSlashings     [2]AttesterSlashing           `json:"attester_slashings"`       // max length 2 to be ensured
+	Attestations          [128]Attestation                `json:"attestations"`             // max length 128 to be ensured
+	Deposits              [16]Deposit                    `json:"deposits"`                 // max length 16 to be ensured
+	VoluntaryExits        [16]SignedVoluntaryExit        `json:"voluntary_exits"`          // max length 16 to be ensured
+	SyncAggregate         SyncAggregate                `json:"sync_aggregate"`
+	ExecutionPayload      ExecutionPayload             `json:"execution_payload"`
+	BlsToExecutionChanges [16]SignedBlsToExecutionChange `json:"bls_to_execution_changes"` // max length 16 to be ensured
+	BlobKzgCommitments    [4096][48]byte                   `json:"blob_kzg_commitments"`     // max length 4096 to be ensured
+} // 1 method
 
-type ExecutionPayload struct{}// 1 method
-func (exe ExecutionPayload) def(){}// default
+// Serialize the BeaconBlockBody to JSON
+func (body *BeaconBlockBody) Serialize() ([]byte, error) {
+	return json.Marshal(body)
+}
 
-type Withdrawwal struct{}
-type ProposalSlashing struct{}
-type SignedBeaconBlockHeader struct{}
-type AttesterSlashing struct{}
-type IndexedAttestation struct{}
-type Attestation struct {}
-type AttestationData struct{}
-type Checkpoint struct{}
-type SignedVoluntaryExit struct{}
-type VoluntaryExit struct{}
-type Deposit struct{}
-type DepositData struct{}
-type Eth1Data struct{}
-type Updatec struct{}
-type FinalityUpdate struct{}
-type OptimisticUpdate struct{}
-type Bootstrap struct{}
+// Deserialize JSON into the BeaconBlockBody
+func Deserialize(data []byte) (*BeaconBlockBody, error) {
+	var exe BeaconBlockBody
+	if err := json.Unmarshal(data, &exe); err != nil {
+		return nil,err
+	}
+	return &exe,nil
+}
 
-type Header struct{}
-type SyncCommittee struct{}
-type SyncAggregate struct{}
 
-type GenericUpdate struct{}
-func (g GenericUpdate)from(){
+func (b *BeaconBlockBody) def() {
+	b.RandaoReveal = SignatureBytes{}
+	b.Eth1Data = Eth1Data{}
+	b.Graffiti = Bytes32{}
+	b.ProposerSlashings = [16]ProposerSlashing{}
+	b.AttesterSlashings = [2]AttesterSlashing{}
+	b.Attestations = [128]Attestation{}
+	b.Deposits = [16]Deposit{}
+	b.VoluntaryExits = [16]SignedVoluntaryExit{}
+	b.SyncAggregate = SyncAggregate{}
+	b.ExecutionPayload = ExecutionPayload{}
+	b.BlsToExecutionChanges = [16]SignedBlsToExecutionChange{}
+	b.BlobKzgCommitments = [4096][48]byte{}
+}
 
+
+
+type SignedBlsToExecutionChange struct{
+	Message   BlsToExecutionChange
+	Signature SignatureBytes
+}
+type BlsToExecutionChange struct{
+	ValidatorIndex uint64
+	FromBlsPubkey [48]byte
+}
+
+type ExecutionPayload struct {
+	ParentHash      Bytes32       `json:"parent_hash"`
+	FeeRecipient    Address       `json:"fee_recipient"`
+	StateRoot       Bytes32       `json:"state_root"`
+	ReceiptsRoot    Bytes32       `json:"receipts_root"`
+	LogsBloom       LogsBloom     `json:"logs_bloom"`
+	PrevRandao      Bytes32       `json:"prev_randao"`
+	BlockNumber     uint64        `json:"block_number"`
+	GasLimit        uint64        `json:"gas_limit"`
+	GasUsed         uint64        `json:"gas_used"`
+	Timestamp       uint64        `json:"timestamp"`
+	ExtraData       [32]byte      `json:"extra_data"`
+	BaseFeePerGas   uint64        `json:"base_fee_per_gas"`
+	BlockHash       Bytes32       `json:"block_hash"`
+	Transactions    [1073741824]byte        `json:"transactions"`    // max length 1073741824 to be implemented
+	Withdrawals     [16]Withdrawal  `json:"withdrawals"`     // max length 16 to be implemented
+	BlobGasUsed     uint64        `json:"blob_gas_used"`   // Deneb variant only
+	ExcessBlobGas   uint64        `json:"excess_blob_gas"` // Deneb variant only
+}   // 1 method
+
+func (exe *ExecutionPayload) def() {
+	exe.ParentHash = Bytes32{}
+	exe.FeeRecipient = Address{}
+	exe.StateRoot = Bytes32{}
+	exe.ReceiptsRoot = Bytes32{}
+	exe.LogsBloom = LogsBloom{}
+	exe.PrevRandao = Bytes32{}
+	exe.BlockNumber = 0
+	exe.GasLimit = 0
+	exe.GasUsed = 0
+	exe.Timestamp = 0
+	exe.ExtraData = [32]byte{}
+	exe.BaseFeePerGas = 0
+	exe.BlockHash = Bytes32{}
+	exe.Transactions =  [1073741824]byte{}       // max length 1073741824 to be implemented
+	exe.Withdrawals = [16]Withdrawal{}          // max length 16 to be implemented
+	exe.BlobGasUsed = 0           // Only for Deneb
+	exe.ExcessBlobGas = 0         // Only for Deneb
+} // default
+
+// Serialize the Deneb variant to JSON
+func (exe *ExecutionPayload) SerializeExecutionPayLoad() ([]byte, error) {
+	return json.Marshal(exe)
+}
+
+// Deserialize JSON into the Deneb variant
+func DeserializeExecutionPayload(data []byte) (*ExecutionPayload, error) {
+	var exe ExecutionPayload
+	if err := json.Unmarshal(data, &exe); err != nil {
+		return nil, err
+	}
+	return &exe, nil
+}
+
+type Withdrawal struct{
+	Index  uint64
+	Amount uint64
+	Address Address
+	ValidatorIndex uint64
+}
+type ProposalSlashing struct {
+	signed_header_1 SignedBeaconBlockHeader
+	signed_header_2 SignedBeaconBlockHeader
+}
+type SignedBeaconBlockHeader struct {
+	message   BeaconBlockHeader
+	signature SignatureBytes
+}
+type AttesterSlashing struct{
+	Attestation1 IndexedAttestation
+	Attestation2 IndexedAttestation
+}
+type IndexedAttestation struct{
+	AttestingIndices [2048]uint64
+	Data AttestationData
+	Signature SignatureBytes
+}
+type Attestation struct {
+	AggregateBits [2048] bool
+	Data          AttestationData
+	Signature     SignatureBytes
+}
+type AttestationData struct{
+	Slot uint64
+	Index uint64
+	BeaconBlockRoot Bytes32
+	Source Checkpoint
+	Target Checkpoint
+}
+type Checkpoint struct{
+	Epoch uint64
+	Root Bytes32
+}
+type SignedVoluntaryExit struct{
+	Message VoluntaryExit
+	Signature SignatureBytes
+}
+type VoluntaryExit struct{
+	Epoch uint64
+	ValidatorIndex uint64
+}
+type Deposit struct{
+	Proof [33]byte
+	Data DepositData
+}
+type DepositData struct{
+	Pubkey [48]byte
+	WitdrawalCredentials [32]byte
+	Amount uint64
+	Signature SignatureBytes
+}
+type Eth1Data struct {
+	DepositRoot  Bytes32
+	DepositCount uint64
+	BlockHash    Bytes32
+}
+type BeaconBlockHeader struct {
+	Slot           uint64
+	ProposeIndex uint64
+	ParentRoot    Bytes32
+	StateRoot     Bytes32
+	BodyRoot      Bytes32
+}
+type Update struct{
+	AttestedHeader Header
+	NextSyncCommittee SyncCommittee
+	NextSyncCommitteBranch []Bytes32
+	FinalizedHeader Header
+	FinalizedBranch []Bytes32
+	SyncAggregate SyncAggregate
+	SignatureSlot uint64
+}
+type FinalityUpdate struct{
+	AttestedHeader Header
+	FinalizedHeader Header
+	FinalizedBranch []Bytes32
+	SyncAggregate SyncAggregate
+	SignatureSlot uint64
+}
+type OptimisticUpdate struct{
+	AttestedHeader Header
+	SyncAggregate SyncAggregate
+	SignatureSlot uint64
+}
+type Bootstrap struct{
+	Header Header
+	CurrentSyncCommittee SyncCommittee
+	CurrentSyncCommitteeBranch []Bytes32
+}
+
+type Header struct{
+	Slot uint64
+	ProposerIndex uint64
+	ParentRoot Bytes32
+	StateRoot Bytes32
+	BodyRoot Bytes32
+}
+type SyncCommittee struct{
+	Pubkeys [512]BLSPubKey
+	AggregatePubkey BLSPubKey
+}
+type SyncAggregate struct{
+	SyncCommitteeBits [512] bool
+	SyncCommitteeSignature SignatureBytes
+}
+type ProposerSlashing struct {
+	SignedHeader1 SignedBeaconBlockHeader
+	SignedHeader2 SignedBeaconBlockHeader
+}
+type GenericUpdate struct{
+	AttestedHeader Header
+	SyncAggregate SyncAggregate
+	SignatureSlot uint64
+	NextSyncCommittee SyncCommittee
+	NextSyncCommitteeBranch []Bytes32
+	FinalizedHeader Header
+	FinalityBranch []Bytes32
+}
+
+func (g GenericUpdate) from() {
+	g.AttestedHeader = Header{}
+	g.SyncAggregate = SyncAggregate{}
+	g.SignatureSlot = 0
+	g.NextSyncCommittee = SyncCommittee{}
+	g.NextSyncCommitteeBranch = [][32]byte{}
+	g.FinalizedHeader = Header{}
+	g.FinalityBranch = [][32]byte{}
 }

--- a/consensus/types/beacon.go
+++ b/consensus/types/beacon.go
@@ -1,8 +1,6 @@
 package types
 
-import (
-	"encoding/json"
-)
+// Serialization and Deserialization for ExecutionPayload and BeaconBlockBody can be done by importing from prewritten functions in utils wherever needed.
 
 type BeaconBlock struct {
 	Slot          uint64
@@ -27,20 +25,6 @@ type BeaconBlockBody struct {
 	BlsToExecutionChanges [16]SignedBlsToExecutionChange `json:"bls_to_execution_changes"` // max length 16 to be ensured
 	BlobKzgCommitments    [4096][48]byte                 `json:"blob_kzg_commitments"`     // max length 4096 to be ensured
 } // 1 method
-
-// Serialize the BeaconBlockBody to JSON
-func (body *BeaconBlockBody) Serialize() ([]byte, error) {
-	return json.Marshal(body)
-}
-
-// Deserialize JSON into the BeaconBlockBody
-func Deserialize(data []byte) (*BeaconBlockBody, error) {
-	var exe BeaconBlockBody
-	if err := json.Unmarshal(data, &exe); err != nil {
-		return nil, err
-	}
-	return &exe, nil
-}
 
 func (b *BeaconBlockBody) Def() {
 	b.RandaoReveal = SignatureBytes{}
@@ -106,19 +90,7 @@ func (exe *ExecutionPayload) Def() {
 	exe.ExcessBlobGas = 0                 // Only for Deneb
 } // default
 
-// Serialize the Deneb variant to JSON
-func (exe *ExecutionPayload) SerializeExecutionPayLoad() ([]byte, error) {
-	return json.Marshal(exe)
-}
 
-// Deserialize JSON into the Deneb variant
-func DeserializeExecutionPayload(data []byte) (*ExecutionPayload, error) {
-	var exe ExecutionPayload
-	if err := json.Unmarshal(data, &exe); err != nil {
-		return nil, err
-	}
-	return &exe, nil
-}
 
 type Withdrawal struct {
 	Index          uint64


### PR DESCRIPTION
Resolves #19 
1) Implemented all the types in the consensus/types directory.
2) The struct fields are capitalized to be exported, If exporting them is not required we can change them later after testing (Currently all struct fields are exported)
3) Size of some containers was to be kept less than some max value so currently I have allotted them fixed size i.e. the maximum size. In future if we come up with some memory efficient alternative it can be changed.
4) Serialization and Deserialization methods are defined for the required structs. (Require Review on whether it is correct or not).