### PR TITLE
Make functions exportable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,7 +25,7 @@ type Config struct {
 // only if we are using CLI
 func (c Config) from_file(configPath *string, network *string, cliConfig *CliConfig) Config {
 	n := Network(*network)
-	baseConfig, err := n.baseConfig(*network)
+	baseConfig, err := n.BaseConfig(*network)
 	if err != nil {
 		baseConfig = BaseConfig{}.Default()
 	}

--- a/config/networks.go
+++ b/config/networks.go
@@ -13,7 +13,7 @@ const (
 	GOERLI  Network = "GOERLI"
 	SEPOLIA Network = "SEPOLIA"
 )
-func (n Network) baseConfig(s string) (BaseConfig, error) {
+func (n Network) BaseConfig(s string) (BaseConfig, error) {
 	switch strings.ToUpper(s) {
 	case "MAINNET":
 		config, err := Mainnet()
@@ -37,7 +37,7 @@ func (n Network) baseConfig(s string) (BaseConfig, error) {
 		return BaseConfig{}, errors.New("network not recognized")
 	}
 }
-func (n Network) chainID (id uint64) (BaseConfig, error) {
+func (n Network) ChainID(id uint64) (BaseConfig, error) {
 	switch id {
 	case 1:
 		config, err := Mainnet()

--- a/config/utils.go
+++ b/config/utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/BlocSoc-iitr/selene/common"
 )
 
-func bytes_serialise(bytes []byte) ([]byte, error) {
+func BytesSerialise(bytes []byte) ([]byte, error) {
 
 	if bytes == nil {
 		return json.Marshal(nil)
@@ -21,7 +21,7 @@ func bytes_serialise(bytes []byte) ([]byte, error) {
 
 }
 
-func bytes_deserialise(data []byte) ([]byte, error) {
+func BytesDeserialise(data []byte) ([]byte, error) {
 	var bytesOpt *string
 	if err := json.Unmarshal(data, &bytesOpt); err != nil {
 		return nil, err

--- a/consensus/consensus_core/consensus_core.go
+++ b/consensus/consensus_core/consensus_core.go
@@ -1,14 +1,10 @@
-// go implementation of consensus_core/src/types/mod.rs
-// structs not defined yet:
-// LightClientStore,genericUpdate
 package consensus_core
-
 type BeaconBlock struct {
 	Slot           uint64
 	Proposer_index uint64
 	Parent_root    [32]byte
-	state_root     [32]byte
-	body           BeaconBlockBody
+	StateRoot      [32]byte
+	Body           BeaconBlockBody
 }
 type Bytes32 [32]byte
 type BLSPubKey [48]byte
@@ -16,154 +12,154 @@ type Address [20]byte
 type LogsBloom = [256]byte
 type SignatureBytes [96]byte
 type Eth1Data struct {
-	deposit_root  Bytes32
-	deposit_count uint64
-	block_hash    Bytes32
+	Deposit_root  Bytes32
+	Deposit_count uint64
+	Block_hash    Bytes32
 }
 type ProposerSlashing struct {
-	signed_header_1 SignedBeaconBlockHeader
-	signed_header_2 SignedBeaconBlockHeader
+	SignedHeader1 SignedBeaconBlockHeader
+	SignedHeader2 SignedBeaconBlockHeader
 }
 type SignedBeaconBlockHeader struct {
-	message   BeaconBlockHeader
-	signature SignatureBytes
+	Message   BeaconBlockHeader
+	Signature SignatureBytes
 }
 type BeaconBlockHeader struct {
-	slot           uint64
-	proposer_index uint64
-	parent_root    Bytes32
-	state_root     Bytes32
-	body_root      Bytes32
+	Slot          uint64
+	ProposerIndex uint64
+	ParentRoot    Bytes32
+	StateRoot     Bytes32
+	BodyRoot      Bytes32
 }
 type AttesterSlashing struct {
-	attestation_1 IndexedAttestation
-	attestation_2 IndexedAttestation
+	Attestation1 IndexedAttestation
+	Attestation2 IndexedAttestation
 }
 type IndexedAttestation struct {
-	attesting_indices []uint64 //max length 2048 to be ensured
-	data              AttestationData
-	signature         SignatureBytes
+	AttestingIndices []uint64 //max length 2048 to be ensured
+	Data             AttestationData
+	Signature        SignatureBytes
 }
 type AttestationData struct {
-	slot              uint64
-	index             uint64
-	beacon_block_root Bytes32
-	source            Checkpoint
-	target            Checkpoint
+	Slot            uint64
+	Index           uint64
+	BeaconBlockRoot Bytes32
+	Source          Checkpoint
+	Target          Checkpoint
 }
 type Checkpoint struct {
-	epoch uint64
-	root  Bytes32
+	Epoch uint64
+	Root  Bytes32
 }
 type Bitlist []bool
 type Attestation struct {
-	aggregation_bits Bitlist `ssz-max:"2048"`
-	data             AttestationData
-	signature        SignatureBytes
+	AggregationBits Bitlist `ssz-max:"2048"`
+	Data            AttestationData
+	Signature       SignatureBytes
 }
 type Deposit struct {
-	proof [33]Bytes32 //fixed size array
-	data  DepositData
+	Proof [33]Bytes32 //fixed size array
+	Data  DepositData
 }
 type DepositData struct {
-	pubkey                 [48]byte
-	withdrawal_credentials Bytes32
-	amount                 uint64
-	signature              SignatureBytes
+	Pubkey                [48]byte
+	WithdrawalCredentials Bytes32
+	Amount                uint64
+	Signature             SignatureBytes
 }
 type SignedVoluntaryExit struct {
-	message   VoluntaryExit
-	signature SignatureBytes
+	Message   VoluntaryExit
+	Signature SignatureBytes
 }
 type VoluntaryExit struct {
-	epoch           uint64
-	validator_index uint64
+	Epoch          uint64
+	ValidatorIndex uint64
 }
 type SyncAggregate struct {
-	sync_committee_bits      [64]byte
-	sync_committee_signature SignatureBytes
+	SyncCommitteeBits      [64]byte
+	SyncCommitteeSignature SignatureBytes
 }
 type Withdrawal struct {
-	index           uint64
-	validator_index uint64
-	address         Address
-	amount          uint64
+	Index          uint64
+	ValidatorIndex uint64
+	Address        Address
+	Amount         uint64
 }
 type ExecutionPayload struct { //not implemented
-	parent_hash      Bytes32
-	fee_recipient    Address
-	state_root       Bytes32
-	receipts_root    Bytes32
-	logs_bloom       LogsBloom
-	prev_randao      Bytes32
-	block_number     uint64
-	gas_limit        uint64
-	gas_used         uint64
-	timestamp        uint64
-	extra_data       [32]byte
-	base_fee_per_gas uint64
-	block_hash       Bytes32
-	transactions     []byte       //max length 1073741824 to be implemented
-	withdrawals      []Withdrawal //max length 16 to be implemented
-	blob_gas_used    uint64
-	excess_blob_gas  uint64
+	ParentHash    Bytes32
+	FeeRecipient  Address
+	StateRoot     Bytes32
+	ReceiptsRoot  Bytes32
+	LogsBloom     LogsBloom
+	PrevRandao    Bytes32
+	BlockNumber   uint64
+	GasLimit      uint64
+	GasUsed       uint64
+	Timestamp     uint64
+	ExtraData     [32]byte
+	BaseFeePerGas uint64
+	BlockHash     Bytes32
+	Transactions  []byte       //max length 1073741824 to be implemented
+	Withdrawals   []Withdrawal //max length 16 to be implemented
+	BlobGasUsed   uint64
+	ExcessBlobGas uint64
 }
 type SignedBlsToExecutionChange struct {
-	message   BlsToExecutionChange
-	signature SignatureBytes
+	Message   BlsToExecutionChange
+	Signature SignatureBytes
 }
 type BlsToExecutionChange struct {
-	validator_index uint64
-	from_bls_pubkey [48]byte
+	ValidatorIndex uint64
+	FromBlsPubkey  [48]byte
 }
 type BeaconBlockBody struct { //not implemented
-	randao_reveal            SignatureBytes
-	eth1_data                Eth1Data
-	graffiti                 Bytes32
-	proposer_slashings       []ProposerSlashing //max length 16 to be insured how?
-	attester_slashings       []AttesterSlashing //max length 2 to be ensured
-	attestations             []Attestation      //max length 128 to be ensured
-	deposits                 []Deposit          //max length 16 to be ensured
-	voluntary_exits          SignedVoluntaryExit
-	sync_aggregate           SyncAggregate
-	execution_payload        ExecutionPayload
-	bls_to_execution_changes []SignedBlsToExecutionChange //max length 16 to be ensured
-	blob_kzg_commitments     [][48]byte                   //max length 4096 to be ensured
+	RandaoReveal          SignatureBytes
+	Eth1Data              Eth1Data
+	Graffiti              Bytes32
+	ProposerSlashings     []ProposerSlashing //max length 16 to be insured how?
+	AttesterSlashings     []AttesterSlashing //max length 2 to be ensured
+	Attestations          []Attestation      //max length 128 to be ensured
+	Deposits              []Deposit          //max length 16 to be ensured
+	VoluntaryExits        SignedVoluntaryExit
+	SyncAggregate         SyncAggregate
+	ExecutionPayload      ExecutionPayload
+	BlsToExecutionChanges []SignedBlsToExecutionChange //max length 16 to be ensured
+	BlobKzgCommitments    [][48]byte                   //max length 4096 to be ensured
 }
 type Header struct {
-	slot           uint64
-	proposer_index uint64
-	parent_root    Bytes32
-	state_root     Bytes32
-	body_root      Bytes32
+	Slot          uint64
+	ProposerIndex uint64
+	ParentRoot    Bytes32
+	StateRoot     Bytes32
+	BodyRoot      Bytes32
 }
 type SyncComittee struct {
-	pubkeys          [512]BLSPubKey
-	aggregate_pubkey BLSPubKey
+	Pubkeys         [512]BLSPubKey
+	AggregatePubkey BLSPubKey
 }
 type Update struct {
-	attested_header            Header
-	next_sync_committee        SyncComittee
-	next_sync_committee_branch []Bytes32
-	finalized_header           Header
-	finality_branch            []Bytes32
-	sync_aggregate             SyncAggregate
-	signature_slot             uint64
+	AttestedHeader          Header
+	NextSyncCommittee       SyncComittee
+	NextSyncCommitteeBranch []Bytes32
+	FinalizedHeader         Header
+	SinalityBranch          []Bytes32
+	SyncAggregate           SyncAggregate
+	SignatureSlot           uint64
 }
 type FinalityUpdate struct {
-	attested_header  Header
-	finalized_header Header
-	finality_branch  []Bytes32
-	sync_aggregate   SyncAggregate
-	signature_slot   uint64
+	AttestedHeader  Header
+	FinalizedHeader Header
+	FinalityBranch  []Bytes32
+	SyncAggregate   SyncAggregate
+	SignatureSlot   uint64
 }
 type OptimisticUpdate struct {
-	attested_header Header
-	sync_aggregate  SyncAggregate
-	signature_slot  uint64
+	AttestedHeader Header
+	SyncAggregate  SyncAggregate
+	SignatureSlot  uint64
 }
 type Bootstrap struct {
-	header                        Header
-	current_sync_committee        SyncComittee
-	current_sync_committee_branch []Bytes32
+	Header                     Header
+	CurrentSyncCommittee       SyncComittee
+	CurrentSyncCommitteeBranch []Bytes32
 }

--- a/consensus/consensus_core/consensus_core.go
+++ b/consensus/consensus_core/consensus_core.go
@@ -4,9 +4,9 @@
 package consensus_core
 
 type BeaconBlock struct {
-	slot           uint64
-	proposer_index uint64
-	parent_root    [32]byte
+	Slot           uint64
+	Proposer_index uint64
+	Parent_root    [32]byte
 	state_root     [32]byte
 	body           BeaconBlockBody
 }

--- a/consensus/database.go
+++ b/consensus/database.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 )
 type Database interface {
-	New(cfg *config.BaseConfig) (Database, error)
+	New(cfg *config.Config) (Database, error)
 	SaveCheckpoint(checkpoint []byte) error
 	LoadCheckpoint() ([]byte, error)
 }
@@ -14,7 +14,7 @@ type FileDB struct {
 	DataDir           string
 	defaultCheckpoint [32]byte
 }
-func (f *FileDB) New(cfg *config.BaseConfig) (Database, error) {
+func (f *FileDB) New(cfg *config.Config) (Database, error) {
 	if cfg.DataDir == nil || *cfg.DataDir == "" {
 		return nil, errors.New("data directory is not set in the config")
 	}
@@ -46,7 +46,7 @@ func (f *FileDB) LoadCheckpoint() ([]byte, error) {
 type ConfigDB struct {
 	checkpoint [32]byte
 }
-func (c *ConfigDB) New(cfg *config.BaseConfig) (Database, error) {
+func (c *ConfigDB) New(cfg *config.Config) (Database, error) {
 	checkpoint := cfg.DefaultCheckpoint
 	if cfg.DataDir == nil {
 		return nil, errors.New("data directory is not set in the config")

--- a/consensus/rpc/mock_rpc.go
+++ b/consensus/rpc/mock_rpc.go
@@ -29,7 +29,7 @@ func (m *MockRpc) GetBootstrap(block_root []byte) (*consensus_core.Bootstrap, er
 	if err != nil {
 		return &consensus_core.Bootstrap{}, fmt.Errorf("bootstrap error: %w", err)
 	}
-	return &bootstrap.data, nil
+	return &bootstrap.Data, nil
 }
 func (m *MockRpc) GetUpdates(period uint64, count uint8) ([]consensus_core.Update, error) {
 	path := filepath.Join(m.testdata, "updates.json")
@@ -44,7 +44,7 @@ func (m *MockRpc) GetUpdates(period uint64, count uint8) ([]consensus_core.Updat
 	}
 	updates := make([]consensus_core.Update, len(updatesResponse))
 	for i, update := range updatesResponse {
-		updates[i] = update.data
+		updates[i] = update.Data
 	}
 	return updates, nil
 }
@@ -59,7 +59,7 @@ func (m *MockRpc) GetFinalityUpdate() (*consensus_core.FinalityUpdate, error) {
 	if err != nil {
 		return &consensus_core.FinalityUpdate{}, fmt.Errorf("finality update error: %w", err)
 	}
-	return &finality.data, nil
+	return &finality.Data, nil
 }
 func (m *MockRpc) GetOptimisticUpdate() (*consensus_core.OptimisticUpdate, error) {
 	path := filepath.Join(m.testdata, "optimistic.json")
@@ -72,7 +72,7 @@ func (m *MockRpc) GetOptimisticUpdate() (*consensus_core.OptimisticUpdate, error
 	if err != nil {
 		return &consensus_core.OptimisticUpdate{}, fmt.Errorf("optimistic update error: %w", err)
 	}
-	return &optimistic.data, nil
+	return &optimistic.Data, nil
 }
 func (m *MockRpc) GetBlock(slot uint64) (*consensus_core.BeaconBlock, error) {
 	path := filepath.Join(m.testdata, fmt.Sprintf("blocks/%d.json", slot))
@@ -85,7 +85,7 @@ func (m *MockRpc) GetBlock(slot uint64) (*consensus_core.BeaconBlock, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &block.data.message, nil
+	return &block.Data.Message, nil
 }
 func (m *MockRpc) ChainId() (uint64, error) {
 	return 0, fmt.Errorf("not implemented")

--- a/consensus/rpc/nimbus_rpc.go
+++ b/consensus/rpc/nimbus_rpc.go
@@ -59,7 +59,7 @@ func (n *NimbusRpc) GetBootstrap(block_root []byte) (consensus_core.Bootstrap, e
 	if err != nil {
 		return consensus_core.Bootstrap{}, fmt.Errorf("bootstrap error: %w", err)
 	}
-	return res.data, nil
+	return res.Data, nil
 }
 func (n *NimbusRpc) GetUpdates(period uint64, count uint8) ([]consensus_core.Update, error) {
 	count = min(count, MAX_REQUEST_LIGHT_CLIENT_UPDATES)
@@ -71,7 +71,7 @@ func (n *NimbusRpc) GetUpdates(period uint64, count uint8) ([]consensus_core.Upd
 	}
 	updates := make([]consensus_core.Update, len(res))
 	for i, update := range res {
-		updates[i] = update.data
+		updates[i] = update.Data
 	}
 	return updates, nil
 }
@@ -82,7 +82,7 @@ func (n *NimbusRpc) GetFinalityUpdate() (consensus_core.FinalityUpdate, error) {
 	if err != nil {
 		return consensus_core.FinalityUpdate{}, fmt.Errorf("finality update error: %w", err)
 	}
-	return res.data, nil
+	return res.Data, nil
 }
 func (n *NimbusRpc) GetOptimisticUpdate() (consensus_core.OptimisticUpdate, error) {
 	req := fmt.Sprintf("%s/eth/v1/beacon/light_client/optimistic_update", n.rpc)
@@ -91,7 +91,7 @@ func (n *NimbusRpc) GetOptimisticUpdate() (consensus_core.OptimisticUpdate, erro
 	if err != nil {
 		return consensus_core.OptimisticUpdate{}, fmt.Errorf("finality update error: %w", err)
 	}
-	return res.data, nil
+	return res.Data, nil
 }
 func (n *NimbusRpc) GetBlock(slot uint64) (consensus_core.BeaconBlock, error) {
 	req := fmt.Sprintf("%s/eth/v2/beacon/blocks/%s", n.rpc, strconv.FormatUint(slot, 10))
@@ -100,7 +100,7 @@ func (n *NimbusRpc) GetBlock(slot uint64) (consensus_core.BeaconBlock, error) {
 	if err != nil {
 		return consensus_core.BeaconBlock{}, fmt.Errorf("block error: %w", err)
 	}
-	return res.data.message, nil
+	return res.Data.Message, nil
 }
 func (n *NimbusRpc) ChainId() (uint64, error) {
 	req := fmt.Sprintf("%s/eth/v1/config/spec", n.rpc)
@@ -109,33 +109,33 @@ func (n *NimbusRpc) ChainId() (uint64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("spec error: %w", err)
 	}
-	return res.data.chain_id, nil
+	return res.Data.ChainId, nil
 }
 // BeaconBlock, Update,FinalityUpdate ,OptimisticUpdate,Bootstrap yet to be defined in consensus-core/src/types/mod.go
 // For now defined in consensus/consensus_core.go
 type BeaconBlockResponse struct {
-	data BeaconBlockData
+	Data BeaconBlockData
 }
 type BeaconBlockData struct {
-	message consensus_core.BeaconBlock
+	Message consensus_core.BeaconBlock
 }
 type UpdateResponse = []UpdateData
 type UpdateData struct {
-	data consensus_core.Update
+	Data consensus_core.Update
 }
 type FinalityUpdateResponse struct {
-	data consensus_core.FinalityUpdate
+	Data consensus_core.FinalityUpdate
 }
 type OptimisticUpdateResponse struct {
-	data consensus_core.OptimisticUpdate
+	Data consensus_core.OptimisticUpdate
 }
 type SpecResponse struct {
-	data Spec
+	Data Spec
 }
 type Spec struct {
-	chain_id uint64
+	ChainId uint64
 }
 type BootstrapResponse struct {
-	data consensus_core.Bootstrap
+	Data consensus_core.Bootstrap
 }
 

--- a/consensus/types/beacon.go
+++ b/consensus/types/beacon.go
@@ -2,6 +2,8 @@ package types
 
 // Serialization and Deserialization for ExecutionPayload and BeaconBlockBody can be done by importing from prewritten functions in utils wherever needed.
 
+
+
 type BeaconBlock struct {
 	Slot          uint64
 	ProposerIndex uint64
@@ -217,7 +219,7 @@ type GenericUpdate struct {
 	FinalityBranch          []Bytes32
 }
 
-func (g GenericUpdate) From() {
+func (g *GenericUpdate) From() {
 	g.AttestedHeader = Header{}
 	g.SyncAggregate = SyncAggregate{}
 	g.SignatureSlot = 0


### PR DESCRIPTION
@star-gazer111 have resolved all the previous errors in linter workflow the current errors are due to unused functions that are not been implemented yet
