### PR TITLE
EvmBuilder and its dependencies #1

### DIFF
--- a/execution/evm/common.go
+++ b/execution/evm/common.go
@@ -1,0 +1,11 @@
+package evm
+import(
+	"github.com/BlocSoc-iitr/selene/common"
+	Common "github.com/ethereum/go-ethereum/common"
+	"math/big"
+)
+type BlockTag = common.BlockTag
+type U256 = *big.Int
+type B256 = Common.Hash
+type Address = common.Address
+type Bytes=[]byte

--- a/execution/evm/context.go
+++ b/execution/evm/context.go
@@ -1,0 +1,136 @@
+package evm
+import (
+	"math/big"
+)
+var BLOCK_HASH_HISTORY = big.NewInt(256)
+type Context[EXT interface{}, DB Database] struct {
+	Evm      EvmContext[DB]
+	External interface{}
+}
+func DefaultContext[EXT interface{}]() Context[EXT, *EmptyDB] {
+    return Context[EXT, *EmptyDB]{
+        Evm:      NewEvmContext(new(EmptyDB)),
+        External: nil,
+    }	
+}
+func NewContext[EXT interface{}, DB Database](evm EvmContext[DB], external EXT) Context[EXT, DB] {
+	return Context[EXT, DB]{
+		Evm:      evm,
+		External: external,
+	}
+}
+type ContextWithHandlerCfg[EXT interface{}, DB Database] struct {
+	Context Context[EXT, DB]
+	Cfg     HandlerCfg
+}
+func (js JournaledState) SetSpecId(spec SpecId) {
+	js.Spec = spec
+}
+//Not being used
+func (c EvmContext[DB]) WithDB(db DB) EvmContext[DB] {
+	return EvmContext[DB]{
+		Inner:       c.Inner.WithDB(db),
+		Precompiles: DefaultContextPrecompiles[DB](),
+	}
+}
+////////////////////////////////////
+///  impl Host for Context /////////
+////////////////////////////////////
+
+// func (c *Context[EXT, DB]) Env() *Env {
+// 	return c.Evm.Inner.Env
+// }
+
+// func (c *Context[EXT, DB]) EnvMut() *Env {
+// 	return c.Evm.Inner.Env
+// }
+
+// func (c *Context[EXT, DB]) LoadAccount(address Address) (LoadAccountResult, bool) {
+// 	res, err := c.Evm.Inner.LoadAccountExist(address)
+// 	if err != nil {
+// 		c.Evm.Inner.Error = err
+// 		return LoadAccountResult{}, false
+// 	}
+// 	return res, true
+// }
+
+// //Get the block hash of the given block `number`.
+// func (c *Context[EXT, DB]) BlockHash(number uint64) (B256, bool) {
+// 	blockNumber := c.Evm.Inner.Env.Block.Number
+// 	requestedNumber := big.NewInt(int64(number))
+
+// 	diff := new(big.Int).Sub(blockNumber, requestedNumber)
+
+// 	if diff.Cmp(big.NewInt(0)) == 0 {
+// 		return common.Hash{}, true
+// 	}
+
+// 	if diff.Cmp(BLOCK_HASH_HISTORY) <= 0 {
+// 		hash, err := c.Evm.Inner.DB.BlockHash(number)
+// 		if err != nil {
+// 			c.Evm.Inner.Error = err
+// 			return common.Hash{}, false
+// 		}
+// 		return hash, true
+// 	}
+
+// 	return common.Hash{}, true
+// }
+
+// // Get balance of `address` and if the account is cold.
+// func (c *Context[EXT, DB]) Balance(address Address) (U256, bool, bool)
+
+// // Get code of `address` and if the account is cold.
+// func (c *Context[EXT, DB]) Code(address Address) (Bytes, bool, bool)
+
+// // Get code hash of `address` and if the account is cold.
+// func (c *Context[EXT, DB]) CodeHash(address Address) (B256, bool, bool)
+
+// // Get storage value of `address` at `index` and if the account is cold.
+// func (c *Context[EXT, DB]) SLoad(address Address, index U256) (U256, bool, bool)
+
+// // Set storage value of account address at index.
+// // Returns (original, present, new, is_cold).
+// func (c *Context[EXT, DB]) SStore(address Address, index U256, value U256) (SStoreResult, bool)
+
+// // Get the transient storage value of `address` at `index`.
+// func (c *Context[EXT, DB]) TLoad(address Address, index U256) U256
+
+// // Set the transient storage value of `address` at `index`.
+// func (c *Context[EXT, DB]) TStore(address Address, index U256, value U256)
+
+// // Emit a log owned by `address` with given `LogData`.
+// func (c *Context[EXT, DB]) Log(log Log [any])
+
+// // Mark `address` to be deleted, with funds transferred to `target`.
+// func (c *Context[EXT, DB]) SelfDestruct(address Address, target Address) (SelfDestructResult, bool)
+
+////////////////////////////////////
+////////////////////////////////////
+////////////////////////////////////
+
+/*
+func (c EvmContext[DB1]) WithNewEvmDB[DB2 Database](db DB2) *EvmContext[ DB2] {
+    return &EvmContext[DB2]{
+		Inner:	   c.Inner.WithDB(db),
+        context: NewContext[EXT, DB2](
+            eb.context.Evm.WithNewDB(db),
+            eb.context.External.(EXT),
+        ),
+        handler: Handler[Context[EXT, DB2], EXT, DB2]{Cfg: eb.handler.Cfg},
+        phantom: struct{}{},
+    }
+}*/
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/execution/evm/evmBuilder.go
+++ b/execution/evm/evmBuilder.go
@@ -1,0 +1,77 @@
+package evm
+type EvmBuilder[EXT interface{}, DB Database] struct {
+	context Context[EXT, DB]
+	handler Handler[Context[EXT, DB], EXT, DB]
+	phantom struct{}
+}
+func NewDefaultEvmBuilder[EXT interface{}]() *EvmBuilder[EXT, *EmptyDB] {
+    handlerCfg := NewHandlerCfg(LATEST)
+    return &EvmBuilder[EXT, *EmptyDB]{
+        context: DefaultContext[EXT](),
+        handler: Handler[Context[EXT, *EmptyDB], EXT, *EmptyDB]{Cfg: handlerCfg},
+        phantom: struct{}{},
+    }
+}
+func WithNewDB[EXT interface{}, DB1, DB2 Database](
+    eb *EvmBuilder[EXT, DB1],
+    db DB2,
+) *EvmBuilder[EXT, DB2] {
+    return &EvmBuilder[EXT, DB2]{
+        context: NewContext[EXT, DB2](
+            WithNewEvmDB(eb.context.Evm, db),
+            eb.context.External.(EXT),
+        ),
+        handler: Handler[Context[EXT, DB2], EXT, DB2]{Cfg: eb.handler.Cfg},
+        phantom: struct{}{},
+    }
+}
+func (eb *EvmBuilder[EXT, DB]) WithEnv(env *Env) *EvmBuilder[EXT, DB] {
+	eb.context.Evm.Inner.Env = env
+	return eb
+}
+
+func (eb *EvmBuilder[EXT, DB]) Build() Evm[EXT,DB] {
+	return NewEvm(eb.context, eb.handler)
+}
+
+func WithContextWithHandlerCfg[EXT interface{},DB1,DB2 Database](eb *EvmBuilder[EXT, DB1],contextWithHandlerCfg ContextWithHandlerCfg[EXT, DB2]) *EvmBuilder[EXT, DB2] {
+	return &EvmBuilder[EXT, DB2]{
+		context: contextWithHandlerCfg.Context,
+		handler: Handler[Context[EXT, DB2], EXT, DB2]{Cfg: contextWithHandlerCfg.Cfg},
+		phantom: struct{}{},
+	}
+}
+//Not in use
+func (eb EvmBuilder[EXT, DB]) WithDB(db DB) *EvmBuilder[EXT, DB] {
+	return &EvmBuilder[EXT, DB]{
+		context: NewContext[EXT, DB](eb.context.Evm.WithDB(db), eb.context.External.(EXT)), //Doubt
+		handler: Handler[Context[EXT, DB], EXT, DB]{Cfg: eb.handler.Cfg},                                              //Doubt
+		phantom: struct{}{},
+	}
+}
+//Not in use
+type PhantomData[T any] struct{}
+//Not in use
+/*
+func WithContextWithHandlerCfg[EXT interface{}, DB Database](eb *EvmBuilder[EXT, Database], contextWithHandlerCfg ContextWithHandlerCfg[EXT, Database]) *EvmBuilder[EXT, Database] {
+    return &EvmBuilder[EXT, Database]{
+        context: contextWithHandlerCfg.Context,
+        handler: Handler[Context[EXT, Database], EXT, Database]{Cfg: contextWithHandlerCfg.Cfg},
+        phantom: struct{}{},
+    }
+}*/
+/*
+func (eb EvmBuilder[EXT, DB]) WithContextWithHandlerCfg(contextWithHandlerCfg ContextWithHandlerCfg[EXT, DB]) *EvmBuilder[EXT, DB] {
+	return &EvmBuilder[EXT, DB]{
+		context: contextWithHandlerCfg.Context,
+		handler: Handler[Context[EXT, DB], EXT, DB]{Cfg: contextWithHandlerCfg.Cfg},
+		phantom: struct{}{},
+	}
+}*/
+
+
+// Tuple implementation in golang:
+
+// LogData represents the data structure of a log entry.
+
+

--- a/execution/evm/evm_context.go
+++ b/execution/evm/evm_context.go
@@ -1,0 +1,20 @@
+package evm
+type EvmContext[DB Database] struct {
+	Inner InnerEvmContext[DB]
+	Precompiles ContextPrecompiles[DB]
+}
+func NewEvmContext[DB Database](db DB) EvmContext[DB] {
+	return EvmContext[DB]{
+		Inner: NewInnerEvmContext[DB](db),
+		Precompiles: DefaultContextPrecompiles[DB](),
+	}
+}
+func WithNewEvmDB[DB1, DB2 Database](
+    ec EvmContext[DB1],
+    db DB2,
+) EvmContext[DB2] {
+    return EvmContext[DB2]{
+        Inner:	   WithNewInnerDB(ec.Inner,db),
+        Precompiles: DefaultContextPrecompiles[DB2](),
+    }
+}

--- a/execution/evm/handler.go
+++ b/execution/evm/handler.go
@@ -1,0 +1,397 @@
+package evm
+type Handler[H Host, EXT any, DB Database] struct {
+	Cfg              HandlerCfg
+	InstructionTable InstructionTables[Context[EXT, DB]]
+	Registers        []HandleRegisters[H, EXT, DB]
+	Validation       ValidationHandler[EXT, DB]
+	PreExecution     PreExecutionHandler[EXT, DB]
+	PostExecution    PostExecutionHandler[EXT, DB]
+	Execution        ExecutionHandler[EXT, DB]
+}
+func NewEvmHandler[H Host, EXT any, DB Database](cfg HandlerCfg) (*EvmHandler[H, EXT, DB], error) {
+	h := &EvmHandler[H, EXT, DB]{Cfg: cfg}
+	if h.Cfg.isOptimism {
+		return h.optimismWithSpec(cfg.specID)
+	}
+	return h.mainnetWithSpec(cfg.specID)
+}
+func (h *EvmHandler[H, EXT, DB]) optimismWithSpec(specid SpecId) (*EvmHandler[H, EXT, DB], error) {
+	return &EvmHandler[H, EXT, DB]{
+        Cfg: HandlerCfg{
+            specID: specid,
+            isOptimism: true,
+        },
+        InstructionTable: NewPlainInstructionTable(InstructionTable[Context[EXT, DB]]{}),
+        Registers: []HandleRegisters[H, EXT, DB]{},
+        Validation: ValidationHandler[EXT, DB]{},
+        PreExecution: PreExecutionHandler[EXT, DB]{},
+        PostExecution: PostExecutionHandler[EXT, DB]{},
+        Execution: ExecutionHandler[EXT, DB]{},
+    }, nil
+}
+func (h *EvmHandler[H, EXT, DB]) mainnetWithSpec(specid SpecId) (*EvmHandler[H, EXT, DB], error) {
+	return &EvmHandler[H, EXT, DB]{
+        Cfg: HandlerCfg{
+            specID: specid,
+            isOptimism: false,
+        },
+        InstructionTable: NewPlainInstructionTable(InstructionTable[Context[EXT, DB]]{}),
+        Registers: []HandleRegisters[H, EXT, DB]{},
+        Validation: ValidationHandler[EXT, DB]{},
+        PreExecution: PreExecutionHandler[EXT, DB]{},
+        PostExecution: PostExecutionHandler[EXT, DB]{},
+        Execution: ExecutionHandler[EXT, DB]{},
+    }, nil
+}
+type HandlerCfg struct {
+	specID     SpecId
+	isOptimism bool
+}
+func NewHandlerCfg(specID SpecId) HandlerCfg {
+	return HandlerCfg{
+		specID:     specID,
+		isOptimism: getDefaultOptimismSetting(),
+	}
+}
+//Note there might be error in specToGeneric needs to be well tested
+
+/*
+Enabling run time flexibility
+# Run with optimism disabled (default)
+go run main.go
+
+# Run with optimism enabled
+OPTIMISM_ENABLED=true go run main.go*/
+// SpecId is the enumeration of various Ethereum hard fork specifications.
+
+// PhantomData is a Go struct that simulates the behavior of Rust's PhantomData.
+func (s SpecId) Enabled(a SpecId, b SpecId) bool {
+	return uint8(a) >= uint8(b)
+}
+func (h *Handler[H, EXT, DB]) ExecuteFrame(frame *Frame, sharedMemory *SharedMemory, context *Context[EXT, DB]) (InterpreterAction, error) {
+	return h.Execution.ExecuteFrame(frame, sharedMemory, &h.InstructionTable, context)
+}
+func (h *EvmHandler[H, EXT, DB]) specId() SpecId {
+	return h.Cfg.specID
+}
+func (h *EvmHandler[H, EXT, DB]) IsOptimism() bool {
+	return isOptimismEnabled && h.Cfg.isOptimism
+}
+
+// EvmHandler is a type alias for Handler with specific type parameters.
+type EvmHandler[H Host, EXT any, DB Database] Handler[H, EXT, DB]
+
+// HandleRegister defines a function type that accepts a pointer to EvmHandler.
+type HandleRegister[H Host, EXT any, DB Database] func(handler *EvmHandler[H, EXT, DB])
+
+// HandleRegisterBox defines a function type as a boxed register.
+type HandleRegisterBox[H Host, EXT any, DB Database] func(handler *EvmHandler[H, EXT, DB])
+
+// HandleRegisters is an interface that defines the `Register` method.
+type HandleRegisters[H Host, EXT any, DB Database] interface {
+	Register(handler *EvmHandler[H, EXT, DB])
+}
+
+// PlainRegister struct implements HandleRegisters with a plain function register.
+type PlainRegister[H Host, EXT any, DB Database] struct {
+	RegisterFn HandleRegister[H, EXT, DB]
+}
+
+// BoxRegister struct implements HandleRegisters with a boxed function register.
+type BoxRegister[H Host, EXT any, DB Database] struct {
+	RegisterFn HandleRegisterBox[H, EXT, DB]
+}
+
+// Register method for PlainRegister, to satisfy HandleRegisters interface.
+func (p PlainRegister[H, EXT, DB]) Register(handler *EvmHandler[H, EXT, DB]) {
+	p.RegisterFn(handler)
+}
+
+// Register method for BoxRegister, to satisfy HandleRegisters interface.
+func (b BoxRegister[H, EXT, DB]) Register(handler *EvmHandler[H, EXT, DB]) {
+	b.RegisterFn(handler)
+}
+/*
+func (s SpecId) IsEnabledIn(spec SpecId) bool {
+	return s.Enabled(s, spec)
+}
+*/
+// String method to provide a string representation for each CallScheme variant.
+// func (cs CallScheme) String() string {
+// 	switch cs {
+// 	case Call_Scheme:
+// 		return "Call"
+// 	case CallCode:
+// 		return "CallCode"
+// 	case DelegateCall:
+// 		return "DelegateCall"
+// 	case StaticCall:
+// 		return "StaticCall"
+// 	case ExtCall:
+// 		return "ExtCall"
+// 	case ExtStaticCall:
+// 		return "ExtStaticCall"
+// 	case ExtDelegateCall:
+// 		return "ExtDelegateCall"
+// 	default:
+// 		return "Unknown"
+// 	}
+// }
+
+/*
+func (s Spec) SpecID() SpecId {
+    return s.SPEC_ID
+}
+*/
+// IsEnabled checks if a specific SpecId is enabled.
+/*func (s Spec) IsEnabled(specId SpecId) bool {
+    return SpecIdEnabled(s.SpecID(), specId)
+}
+func SpecIdEnabled(our, other SpecId) bool {
+    return our >= other
+}*/
+/*
+func NewHandler[H Host, EXT any, DB Database](cfg HandlerCfg) Handler[H, EXT, DB] {
+    return createHandlerWithConfig[H, EXT, DB](cfg)
+}*/
+/*
+func createHandlerWithConfig[H Host, EXT any, DB Database](cfg HandlerCfg) Handler[H, EXT, DB] {
+    spec := GetSpecforID[H, EXT, DB](cfg.specID)
+
+    if cfg.isOptimism {
+        return createOptimismHandler(spec)
+    }
+    return createMainnetHandler(spec)
+}
+*/
+
+/*
+func (h *EvmHandler[H,EXT, DB])optimism() *EvmHandler[H,EXT, DB]{
+    handler:=
+}*/
+//Doubt in newplaininstructiontable
+/*
+func (h *EvmHandler[H,EXT, DB])mainnet(spec Spec) *EvmHandler[H,EXT, DB]{
+    specID := spec.SpecID()
+
+    return &EvmHandler[H, EXT, DB]{
+        Cfg: NewHandlerCfg(specID),
+        InstructionTable: NewPlainInstructionTable(InstructionTable[H]{}),
+        Registers: []HandleRegister[H, EXT, DB]{},
+
+
+    }
+}*/
+/*
+func specToGeneric[H Host, EXT any, DB Database](
+    specID SpecId,
+    h *EvmHandler[H, EXT, DB],
+    isOptimism bool,
+) (*EvmHandler[H, EXT, DB], error) {
+    switch specID {
+    case FRONTIER, FRONTIER_THAWING:
+        return createSpecHandler[H, EXT, DB](h, "frontier", isOptimism)
+    case HOMESTEAD, DAO_FORK:
+        return createSpecHandler[H, EXT, DB](h, "homestead", isOptimism)
+    case TANGERINE:
+        return createSpecHandler[H, EXT, DB](h, "tangerine", isOptimism)
+    case SPURIOUS_DRAGON:
+        return createSpecHandler[H, EXT, DB](h, "spurious_dragon", isOptimism)
+    case BYZANTIUM:
+        return createSpecHandler[H, EXT, DB](h, "byzantium", isOptimism)
+    case PETERSBURG, CONSTANTINOPLE:
+        return createSpecHandler[H, EXT, DB](h, "petersburg", isOptimism)
+    case ISTANBUL, MUIR_GLACIER:
+        return createSpecHandler[H, EXT, DB](h, "istanbul", isOptimism)
+    case BERLIN:
+        return createSpecHandler[H, EXT, DB](h, "berlin", isOptimism)
+    case LONDON, ARROW_GLACIER, GRAY_GLACIER:
+        return createSpecHandler[H, EXT, DB](h, "london", isOptimism)
+    case MERGE:
+        return createSpecHandler[H, EXT, DB](h, "merge", isOptimism)
+    case SHANGHAI:
+        return createSpecHandler[H, EXT, DB](h, "shanghai", isOptimism)
+    case CANCUN:
+        return createSpecHandler[H, EXT, DB](h, "cancun", isOptimism)
+    case PRAGUE:
+        return createSpecHandler[H, EXT, DB](h, "prague", isOptimism)
+    case PRAGUE_EOF:
+        return createSpecHandler[H, EXT, DB](h, "prague_eof", isOptimism)
+    case LATEST:
+        return createSpecHandler[H, EXT, DB](h, "latest", isOptimism)
+    }
+
+    // Optimism-specific specs
+    if isOptimism {
+        switch specID {
+        case BEDROCK:
+            return createSpecHandler[H, EXT, DB](h, "bedrock", true)
+        case REGOLITH:
+            return createSpecHandler[H, EXT, DB](h, "regolith", true)
+        case CANYON:
+            return createSpecHandler[H, EXT, DB](h, "canyon", true)
+        case ECOTONE:
+            return createSpecHandler[H, EXT, DB](h, "ecotone", true)
+        case FJORD:
+            return createSpecHandler[H, EXT, DB](h, "fjord", true)
+        }
+    }
+
+    return nil, fmt.Errorf("unsupported spec ID: %d", specID)
+}
+
+*/
+/*
+// Concrete spec implementations
+type FrontierSpec struct{}
+type HomesteadSpec struct{}
+type TangerineSpec struct{}
+type SpuriousDragonSpec struct{}
+type ByzantiumSpec struct{}
+type PetersburgSpec struct{}
+type IstanbulSpec struct{}
+type BerlinSpec struct{}
+type LondonSpec struct{}
+type MergeSpec struct{}
+type ShanghaiSpec struct{}
+type CancunSpec struct{}
+type PragueSpec struct{}
+type PragueEofSpec struct{}
+type LatestSpec struct{}
+
+// Optimism-specific specs
+type BedrockSpec struct{}
+type RegolithSpec struct{}
+type CanyonSpec struct{}
+type EcotoneSpec struct{}
+type FjordSpec struct{}
+
+func (s *FrontierSpec) Name() string         { return "frontier" }
+func (s *FrontierSpec) Version() uint        { return 1 }
+func (s *HomesteadSpec) Name() string        { return "homestead" }
+func (s *HomesteadSpec) Version() uint       { return 1 }
+func (s *TangerineSpec) Name() string        { return "tangerine" }
+func (s *TangerineSpec) Version() uint       { return 1 }
+func (s *SpuriousDragonSpec) Name() string   { return "spurious_dragon" }
+func (s *SpuriousDragonSpec) Version() uint  { return 1 }
+func (s *ByzantiumSpec) Name() string        { return "byzantium" }
+func (s *ByzantiumSpec) Version() uint       { return 1 }
+func (s *PetersburgSpec) Name() string       { return "petersburg" }
+func (s *PetersburgSpec) Version() uint      { return 1 }
+func (s *IstanbulSpec) Name() string         { return "istanbul" }
+func (s *IstanbulSpec) Version() uint        { return 1 }
+func (s *BerlinSpec) Name() string           { return "berlin" }
+func (s *BerlinSpec) Version() uint          { return 1 }
+func (s *LondonSpec) Name() string           { return "london" }
+func (s *LondonSpec) Version() uint          { return 1 }
+func (s *MergeSpec) Name() string            { return "merge" }
+func (s *MergeSpec) Version() uint           { return 1 }
+func (s *ShanghaiSpec) Name() string         { return "shanghai" }
+func (s *ShanghaiSpec) Version() uint        { return 1 }
+func (s *CancunSpec) Name() string           { return "cancun" }
+func (s *CancunSpec) Version() uint          { return 1 }
+func (s *PragueSpec) Name() string           { return "prague" }
+func (s *PragueSpec) Version() uint          { return 1 }
+func (s *PragueEofSpec) Name() string        { return "prague_eof" }
+func (s *PragueEofSpec) Version() uint       { return 1 }
+func (s *LatestSpec) Name() string           { return "latest" }
+func (s *LatestSpec) Version() uint          { return 1 }
+func (s *BedrockSpec) Name() string          { return "bedrock" }
+func (s *BedrockSpec) Version() uint         { return 1 }
+func (s *RegolithSpec) Name() string         { return "regolith" }
+func (s *RegolithSpec) Version() uint        { return 1 }
+func (s *CanyonSpec) Name() string           { return "canyon" }
+func (s *CanyonSpec) Version() uint          { return 1 }
+func (s *EcotoneSpec) Name() string          { return "ecotone" }
+func (s *EcotoneSpec) Version() uint         { return 1 }
+func (s *FjordSpec) Name() string            { return "fjord" }
+func (s *FjordSpec) Version() uint           { return 1 }
+*/
+// createSpecHandler now creates the appropriate spec implementation
+/*
+func createSpecHandler[H Host, EXT any, DB Database](
+    h *EvmHandler[H, EXT, DB],
+    specName string,
+    isOptimism bool,
+) (*EvmHandler[H, EXT, DB], error) {
+    newHandler := *h
+
+    var spec Spec
+    switch specName {
+    case "frontier":
+        spec = &FrontierSpec{}
+    case "homestead":
+        spec = &HomesteadSpec{}
+    case "tangerine":
+        spec = &TangerineSpec{}
+    case "spurious_dragon":
+        spec = &SpuriousDragonSpec{}
+    case "byzantium":
+        spec = &ByzantiumSpec{}
+    case "petersburg":
+        spec = &PetersburgSpec{}
+    case "istanbul":
+        spec = &IstanbulSpec{}
+    case "berlin":
+        spec = &BerlinSpec{}
+    case "london":
+        spec = &LondonSpec{}
+    case "merge":
+        spec = &MergeSpec{}
+    case "shanghai":
+        spec = &ShanghaiSpec{}
+    case "cancun":
+        spec = &CancunSpec{}
+    case "prague":
+        spec = &PragueSpec{}
+    case "prague_eof":
+        spec = &PragueEofSpec{}
+    case "latest":
+        spec = &LatestSpec{}
+    /*
+    case "bedrock":
+        spec = &BedrockSpec{}
+    case "regolith":
+        spec = &RegolithSpec{}
+    case "canyon":
+        spec = &CanyonSpec{}
+    case "ecotone":
+        spec = &EcotoneSpec{}
+    case "fjord":
+        spec = &FjordSpec{}
+*/
+/*
+    default:
+        return nil, fmt.Errorf("unknown spec: %s", specName)
+    }
+
+    // Add the spec to the handler
+    newHandler = spec
+    return &newHandler, nil
+}
+*/
+/*
+func withSpec[EXT any, DB Database, S Spec](h *EVMHandler[EXT, DB]) (*EVMHandler[EXT, DB], error) {
+    var spec S
+    rules := spec.Rules()
+
+    // Create a new handler with the specific spec configuration
+    newHandler := &EVMHandler[EXT, DB]{
+        cfg: h.cfg,
+        spec: spec,
+        rules: *rules,
+    }
+
+    return newHandler, nil
+}*/
+
+/*
+type HandleRegister[EXT any, DB Database] func(handler *EvmHandler[EXT, DB])
+type EvmHandler[EXT any, DB Database] Handler[EXT, DB]
+type HandleRegisterBox[EXT any, DB Database] interface {
+    Call(handler *EvmHandler[EXT, DB])
+}
+type HandleRegisters[EXT any, DB Database] struct {
+    Plain HandleRegister[EXT, DB]      // Plain function register
+    Box   HandleRegisterBox[EXT, DB]   // Boxed function register
+}*/

--- a/execution/evm/inner_evm_context.go
+++ b/execution/evm/inner_evm_context.go
@@ -1,0 +1,62 @@
+package evm
+type InnerEvmContext[DB Database] struct {
+    Env                    *Env
+    JournaledState        JournaledState
+    DB                     DB
+    Error                  error
+    ValidAuthorizations    []Address
+    L1BlockInfo           *L1BlockInfo // For optimism feature
+}
+func NewInnerEvmContext[DB Database](db DB) InnerEvmContext[DB] {
+	SpecId:=DefaultSpecId()
+	return InnerEvmContext[DB]{
+		Env: &Env{},
+		JournaledState: NewJournalState(SpecId,make(map[Address]struct{})),//to be changed
+		DB: db,
+		Error: nil,
+		ValidAuthorizations: nil,
+		L1BlockInfo: nil,
+	}
+}
+func WithNewInnerDB[DB1, DB2 Database](
+    inner InnerEvmContext[DB1],
+    db DB2,
+) InnerEvmContext[DB2] {
+    return InnerEvmContext[DB2]{
+        Env:                 inner.Env,
+        JournaledState:     inner.JournaledState,
+        DB:                 db,
+        Error:              inner.Error,
+        ValidAuthorizations: nil,
+        L1BlockInfo:        inner.L1BlockInfo,
+    }
+}
+func (i *InnerEvmContext[DB]) TakeError() EvmError {
+    currentError := i.Error
+    i.Error = nil
+    return EvmError{Message: currentError.Error()}
+}
+type L1BlockInfo struct {
+	L1BaseFee           U256
+	L1FeeOverhead       *U256
+	L1BaseFeeScalar     U256
+	L1BlobBaseFee       *U256
+	L1BlobBaseFeeScalar *U256
+	EmptyScalars        bool
+}
+//Not being used in the code
+func (inner InnerEvmContext[DB]) WithDB(db DB) InnerEvmContext[DB] {
+	return InnerEvmContext[DB]{
+		Env:                 inner.Env,
+		JournaledState:      inner.JournaledState,
+		DB:                  db,
+		Error:               inner.Error,
+		ValidAuthorizations: nil,
+		L1BlockInfo:         inner.L1BlockInfo,
+	}
+}
+//Not being used in the code
+func (inner InnerEvmContext[DB]) specId() SpecId {
+	return inner.JournaledState.Spec
+}
+

--- a/execution/evm/journal.go
+++ b/execution/evm/journal.go
@@ -1,0 +1,50 @@
+package evm
+import (
+	"github.com/BlocSoc-iitr/selene/common"
+)
+type JournaledState struct {
+	State EvmState
+	TransientStorage TransientStorage
+	Logs []Log[LogData] 
+	Depth uint
+	Journal [][]JournalEntry
+	Spec SpecId
+	WarmPreloadedAddresses map[Address]struct{}
+}
+func NewJournalState(spec SpecId,warmPreloadedAddresses map[Address]struct{}) JournaledState {
+	return JournaledState{
+		State: nil,
+		TransientStorage: nil,
+		Logs: []Log[LogData] {},
+		Depth: 0,
+		Journal: [][]JournalEntry{},
+		Spec: spec,
+		WarmPreloadedAddresses: warmPreloadedAddresses,
+	}
+}
+type JournalCheckpoint struct {
+	Log_i     uint
+	Journal_i uint
+}
+func (j JournaledState)setSpecId(spec SpecId) {
+	j.Spec = spec
+}
+type TransientStorage map[Key]U256
+type EvmState map[common.Address]Account
+type Key struct {
+	Account common.Address
+	Slot    U256
+}
+type Log[T any] struct {
+	// The address which emitted this log.
+	Address Address `json:"address"`
+	// The log data.
+	Data T `json:"data"`
+}
+type LogData struct {
+	// The indexed topic list.
+	Topics []B256 `json:"topics"`
+	// The plain data.
+	Data Bytes `json:"data"`
+}
+

--- a/execution/evm/journal_entry.go
+++ b/execution/evm/journal_entry.go
@@ -1,0 +1,148 @@
+package evm
+import(
+	"encoding/json"
+	"math/big"
+	)
+type JournalEntryType uint8
+const (
+	AccountWarmedType JournalEntryType = iota
+	AccountDestroyedType
+	AccountTouchedType
+	BalanceTransferType
+	NonceChangeType
+	AccountCreatedType
+	StorageChangedType
+	StorageWarmedType
+	TransientStorageChangeType
+	CodeChangeType
+)
+
+// Creating a struct for JournalEntry containing all possible fields that might be needed
+type JournalEntry struct {
+	Type         JournalEntryType
+	Address      Address
+	Target       Address // Used for AccountDestroyed
+	WasDestroyed bool    // Used for AccountDestroyed
+	HadBalance   U256    // Used for AccountDestroyed
+	Balance      U256    // Used for BalanceTransfer
+	From         Address // Used for BalanceTransfer
+	To           Address // Used for BalanceTransfer
+	Key          U256    // Used for Storage operations
+	HadValue     U256    // Used for Storage operations
+}
+
+func NewAccountWarmedEntry(address Address) *JournalEntry {
+	return &JournalEntry{
+		Type:    AccountWarmedType,
+		Address: address,
+	}
+}
+
+// NewAccountDestroyedEntry creates a new journal entry for destroying an account
+func NewAccountDestroyedEntry(address, target Address, wasDestroyed bool, hadBalance U256) *JournalEntry {
+	return &JournalEntry{
+		Type:         AccountDestroyedType,
+		Address:      address,
+		Target:       target,
+		WasDestroyed: wasDestroyed,
+		HadBalance:   new(big.Int).Set(hadBalance), //to avoid mutating the original value (had balance not written directly)
+	}
+}
+
+// NewAccountTouchedEntry creates a new journal entry for touching an account
+func NewAccountTouchedEntry(address Address) *JournalEntry {
+	return &JournalEntry{
+		Type:    AccountTouchedType,
+		Address: address,
+	}
+}
+
+// NewBalanceTransferEntry creates a new journal entry for balance transfer
+func NewBalanceTransferEntry(from, to Address, balance U256) *JournalEntry {
+	return &JournalEntry{
+		Type:    BalanceTransferType,
+		From:    from,
+		To:      to,
+		Balance: new(big.Int).Set(balance),
+	}
+}
+
+// NewNonceChangeEntry creates a new journal entry for nonce change
+func NewNonceChangeEntry(address Address) *JournalEntry {
+	return &JournalEntry{
+		Type:    NonceChangeType,
+		Address: address,
+	}
+}
+
+// NewAccountCreatedEntry creates a new journal entry for account creation
+func NewAccountCreatedEntry(address Address) *JournalEntry {
+	return &JournalEntry{
+		Type:    AccountCreatedType,
+		Address: address,
+	}
+}
+
+// NewStorageChangedEntry creates a new journal entry for storage change
+func NewStorageChangedEntry(address Address, key, hadValue U256) *JournalEntry {
+	return &JournalEntry{
+		Type:     StorageChangedType,
+		Address:  address,
+		Key:      new(big.Int).Set(key),
+		HadValue: new(big.Int).Set(hadValue),
+	}
+}
+
+// NewStorageWarmedEntry creates a new journal entry for storage warming
+func NewStorageWarmedEntry(address Address, key U256) *JournalEntry {
+	return &JournalEntry{
+		Type:    StorageWarmedType,
+		Address: address,
+		Key:     new(big.Int).Set(key),
+	}
+}
+
+// NewTransientStorageChangeEntry creates a new journal entry for transient storage change
+func NewTransientStorageChangeEntry(address Address, key, hadValue U256) *JournalEntry {
+	return &JournalEntry{
+		Type:     TransientStorageChangeType,
+		Address:  address,
+		Key:      new(big.Int).Set(key),
+		HadValue: new(big.Int).Set(hadValue),
+	}
+}
+
+// NewCodeChangeEntry creates a new journal entry for code change
+func NewCodeChangeEntry(address Address) *JournalEntry {
+	return &JournalEntry{
+		Type:    CodeChangeType,
+		Address: address,
+	}
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (j JournalEntry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type         JournalEntryType `json:"type"`
+		Address      Address          `json:"address"`
+		Target       Address          `json:"target,omitempty"`
+		WasDestroyed bool             `json:"was_destroyed,omitempty"`
+		HadBalance   U256             `json:"had_balance,omitempty"`
+		Balance      U256             `json:"balance,omitempty"`
+		From         Address          `json:"from,omitempty"`
+		To           Address          `json:"to,omitempty"`
+		Key          U256             `json:"key,omitempty"`
+		HadValue     U256             `json:"had_value,omitempty"`
+	}{
+		Type:         j.Type,
+		Address:      j.Address,
+		Target:       j.Target,
+		WasDestroyed: j.WasDestroyed,
+		HadBalance:   j.HadBalance,
+		Balance:      j.Balance,
+		From:         j.From,
+		To:           j.To,
+		Key:          j.Key,
+		HadValue:     j.HadValue,
+	})
+}

--- a/execution/evm/precompiles.go
+++ b/execution/evm/precompiles.go
@@ -1,0 +1,121 @@
+package evm
+import (
+	"sync"
+)
+	func (e *EvmContext[DB]) SetPrecompiles(precompiles ContextPrecompiles[DB]) {
+		for i, address := range precompiles.Inner.StaticRef.Addresses {
+			e.Inner.JournaledState.WarmPreloadedAddresses[i] = address
+		}
+		e.Precompiles = precompiles
+	}
+	type ContextPrecompiles[DB Database] struct {
+		Inner PrecompilesCow[DB]
+	}
+	func DefaultContextPrecompiles[DB Database]() ContextPrecompiles[DB] {
+		return ContextPrecompiles[DB]{
+			Inner: NewPrecompilesCow[DB](),
+		}
+	}
+	func NewPrecompilesCow[DB Database]() PrecompilesCow[DB] {
+		return PrecompilesCow[DB]{
+			Owned: make(map[Address]ContextPrecompile[DB]),
+		}
+	}
+	type PrecompilesCow[DB Database] struct {
+		isStatic  bool	
+		StaticRef *Precompiles
+		Owned     map[Address]ContextPrecompile[DB]
+	}
+	type Precompiles struct {
+		Inner     map[Address]Precompile
+		Addresses map[Address]struct{}
+	}
+	type Precompile struct {
+		precompileType string // "Standard", "Env", "Stateful", or "StatefulMut"
+		standard       StandardPrecompileFn
+		env            EnvPrecompileFn
+		stateful       *StatefulPrecompileArc
+		statefulMut    *StatefulPrecompileBox
+	}
+	type StandardPrecompileFn func(input *Bytes, gasLimit uint64) PrecompileResult
+	type EnvPrecompileFn func(input *Bytes, gasLimit uint64, env *Env) PrecompileResult
+	type StatefulPrecompile interface {
+		Call(bytes *Bytes, gasLimit uint64, env *Env) PrecompileResult
+	}
+	type StatefulPrecompileMut interface {
+		CallMut(bytes *Bytes, gasLimit uint64, env *Env) PrecompileResult
+		Clone() StatefulPrecompileMut
+	}
+	
+	// Doubt
+	type StatefulPrecompileArc struct {
+		sync.RWMutex
+		impl StatefulPrecompile
+	}
+	
+	// StatefulPrecompileBox is a mutable reference to a StatefulPrecompileMut
+	type StatefulPrecompileBox struct {
+		impl StatefulPrecompileMut
+	}
+	type ContextPrecompile[DB Database] struct {
+		precompileType     string // "Ordinary", "ContextStateful", or "ContextStatefulMut"
+		ordinary           *Precompile
+		contextStateful    *ContextStatefulPrecompileArc[DB]
+		contextStatefulMut *ContextStatefulPrecompileBox[DB]
+	}
+	
+	// ContextStatefulPrecompileArc is a thread-safe reference to a ContextStatefulPrecompile
+	type ContextStatefulPrecompileArc[DB Database] struct {
+		sync.RWMutex
+		impl ContextStatefulPrecompile[DB]
+	}
+	
+	// ContextStatefulPrecompileBox is a mutable reference to a ContextStatefulPrecompileMut
+	type ContextStatefulPrecompileBox[DB Database] struct {
+		impl ContextStatefulPrecompileMut[DB]
+	}
+	type ContextStatefulPrecompile[DB Database] interface {
+		Call(bytes *Bytes, gasLimit uint64, evmCtx *InnerEvmContext[DB]) PrecompileResult
+	}
+	
+	// ContextStatefulPrecompileMut interface for mutable stateful precompiles with context
+	type ContextStatefulPrecompileMut[DB Database] interface {
+		CallMut(bytes *Bytes, gasLimit uint64, evmCtx *InnerEvmContext[DB]) PrecompileResult
+		Clone() ContextStatefulPrecompileMut[DB]
+	}
+	type PrecompileResult struct {
+		output *PrecompileOutput
+		err    PrecompileErrorStruct //Doubt
+	}
+	type PrecompileOutput struct {
+		GasUsed uint64
+		Bytes   []byte
+	}
+	type PrecompileErrorStruct struct {
+		errorType string
+		message   string
+	}
+	
+	const (
+		ErrorOutOfGas                 = "OutOfGas"
+		ErrorBlake2WrongLength        = "Blake2WrongLength"
+		ErrorBlake2WrongFinalFlag     = "Blake2WrongFinalIndicatorFlag"
+		ErrorModexpExpOverflow        = "ModexpExpOverflow"
+		ErrorModexpBaseOverflow       = "ModexpBaseOverflow"
+		ErrorModexpModOverflow        = "ModexpModOverflow"
+		ErrorBn128FieldPointNotMember = "Bn128FieldPointNotAMember"
+		ErrorBn128AffineGFailedCreate = "Bn128AffineGFailedToCreate"
+		ErrorBn128PairLength          = "Bn128PairLength"
+		ErrorBlobInvalidInputLength   = "BlobInvalidInputLength"
+		ErrorBlobMismatchedVersion    = "BlobMismatchedVersion"
+		ErrorBlobVerifyKzgProofFailed = "BlobVerifyKzgProofFailed"
+		ErrorOther                    = "Other"
+	)
+	
+	// Error implementation for PrecompileError
+	func (e PrecompileErrorStruct) Error() string {
+		if e.message != "" {
+			return e.message
+		}
+		return e.errorType
+	}


### PR DESCRIPTION
FIles Overview : 
Common File Common.go
1)EvmBuilder.go: generic builder for creating EVM instances. creating a default builder, updating the database, and modifying the environment settings for the EVM.
2)Handler.go:
This file defines the Handler and EvmHandler types for managing Ethereum Virtual Machine (EVM) execution contexts in Go. It includes configuration structures (HandlerCfg), methods for initializing handlers for different Ethereum specifications (mainnet and optimism) 
Build FLags used for optimism 
to enable them add it in gopls through settings
"gopls": {
    "buildFlags": ["optimism"]
}

3)Context.go : creating and managing the contexts necessary for executing EVM operations
4)EvmContext.go:managing the EVM context within a specified database environment
5)Precompiles.go: integrating and executing precompiles in an EVM environment

6)InnerEvmContext.go:manage the internal state of the EVM execution environment. L1 block info holds parameters related to layer 1 block information
7)Journal.go:managing the state of evm environment
8)Journal_Entry.go :tracking state changes (account changes and storage modifications)

Files contain some commented out functions  And some functions with comment not in use No need to test them 

