### PR TITLE
implementing correct AccessList

### DIFF
--- a/execution/types.go
+++ b/execution/types.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"reflect"
 )
+type B256 = common.Hash
 
 type FeeHistory struct {
 	BaseFeePerGas []hexutil.Big
@@ -50,7 +51,11 @@ type CallOpts struct {
 	Value    *big.Int        `json:"value,omitempty"`
 	Data     []byte          `json:"data,omitempty"`
 }
-
+type AccessListItem struct {
+	Address     common.Address //I used Common here instead of common
+	StorageKeys []B256
+}
+type AccessList []AccessListItem
 func (c *CallOpts) String() string {
 	return fmt.Sprintf("CallOpts{From: %v, To: %v, Gas: %v, GasPrice: %v, Value: %v, Data: 0x%x}",
 		c.From, c.To, c.Gas, c.GasPrice, c.Value, c.Data)


### PR DESCRIPTION
Resolves [issue#92](https://github.com/BlocSoc-iitr/selene/issues/92) 
Following changes need to be done : 
Since accesslist is defined in execution/types.go 
So the following files should use this accesslist instead of the one used from geth types github.com/ethereum/go-ethereum/core/types 

#92 
[common/types.go](https://github.com/BlocSoc-iitr/selene/blob/dev/common/types.go)
[execution/http_rpc.go](https://github.com/BlocSoc-iitr/selene/blob/dev/execution/http_rpc.go)
[execution/rpc.go](https://github.com/BlocSoc-iitr/selene/blob/dev/execution/rpc.go)